### PR TITLE
Sudoku Fixes

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/PlaySudoku.iml
+++ b/.idea/PlaySudoku.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,19 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <option name="scopesOrder">
+      <list>
+        <option value="All Changed Files" />
+        <option value="Open Files" />
+        <option value="Production" />
+        <option value="Project Files" />
+        <option value="Scratches and Consoles" />
+        <option value="Tests" />
+      </list>
+    </option>
+    <inspection_tool class="AutoCloseableResource" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="METHOD_MATCHER_CONFIG" value="java.util.Formatter,format,java.io.Writer,append,com.google.common.base.Preconditions,checkNotNull,org.hibernate.Session,close,java.io.PrintWriter,printf,java.io.PrintStream,printf,java.util.Hashtable,remove" />
+    </inspection_tool>
+    <inspection_tool class="SingleStatementInBlock" enabled="true" level="WEAK WARNING" enabled_by_default="true" editorAttributes="INFO_ATTRIBUTES" />
+  </profile>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="19" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/PlaySudoku.iml" filepath="$PROJECT_DIR$/.idea/PlaySudoku.iml" />
+      <module fileurl="file://$PROJECT_DIR$/client.app/client.app.iml" filepath="$PROJECT_DIR$/client.app/client.app.iml" />
+      <module fileurl="file://$PROJECT_DIR$/remote.obj/remote.obj.iml" filepath="$PROJECT_DIR$/remote.obj/remote.obj.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/client.app/client.app.iml
+++ b/client.app/client.app.iml
@@ -3,11 +3,12 @@
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="lib" level="project" />
     <orderEntry type="module" module-name="remote.obj" />
+    <orderEntry type="library" name="JavaFX19" level="application" />
   </component>
 </module>

--- a/client.app/src/module-info.java
+++ b/client.app/src/module-info.java
@@ -7,6 +7,8 @@ module client.app {
     requires java.desktop;
     requires remote.obj;
 
+    opens sudoku.controllers to javafx.fxml;
+
     exports sudoku;
     exports sudoku.services;
     exports sudoku.servicesImpls;

--- a/client.app/src/sudoku/controllers/HomeViewSudokuController.java
+++ b/client.app/src/sudoku/controllers/HomeViewSudokuController.java
@@ -1,12 +1,5 @@
 package sudoku.controllers;
 
-import java.io.IOException;
-import java.net.URL;
-import java.rmi.RemoteException;
-import java.time.LocalDate;
-import java.util.ResourceBundle;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import javafx.event.ActionEvent;
 import javafx.event.Event;
 import javafx.fxml.FXML;
@@ -24,6 +17,14 @@ import server.entities.Player;
 import server.entities.SudokuLevel;
 import sudoku.services.ClientService;
 import sudoku.servicesImpls.ClientServiceImpl;
+
+import java.io.IOException;
+import java.net.URL;
+import java.rmi.RemoteException;
+import java.time.LocalDate;
+import java.util.ResourceBundle;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Контролер на заглавния прозорец.
@@ -52,34 +53,33 @@ public class HomeViewSudokuController {
 
     /**
      * Създава дъска и инициализира нейните стойности според нивото на трудност на предстоящата игра.
+     *
      * @param level - ниво на трудност.
      * @throws RemoteException
      */
     private int[][] makeBoard(SudokuLevel level) throws RemoteException {
         ClientService cl = new ClientServiceImpl();
-        int[][] board = cl.initGame(level, nicknameTxtField.getText());
 
-        return board;
+        return cl.initGame(level, nicknameTxtField.getText());
     }
 
     /**
      * Инициализира сцената със судоку пъзела.
+     *
      * @param actionEvent - събитие.
      */
     private void sendSudokuScene(Event actionEvent, Pair<Game, Player> data) {
         Stage s = (Stage) ((Node) actionEvent.getSource()).getScene().getWindow();
-        try{
-            FXMLLoader loader = new FXMLLoader(getClass().getResource("../fxmls/PlaySudoku.fxml"));
+        try {
+            FXMLLoader loader = new FXMLLoader(getClass().getResource("/sudoku/fxmls/PlaySudoku.fxml"));
             Parent root = loader.load();
             Scene sc = new Scene(root);
-
             s.setUserData(data);
-            if(loader.getController().getClass() == PlaySudokuController.class){
-                ((PlaySudokuController)loader.getController()).receive(s);
+            if (loader.getController().getClass() == PlaySudokuController.class) {
+                ((PlaySudokuController) loader.getController()).receive(s);
             }
 
             s.setScene(sc);
-            s.showAndWait();
         } catch (IOException e) {
             logger.log(Level.SEVERE, LocalDate.now() + e.getMessage());
         }
@@ -87,6 +87,7 @@ public class HomeViewSudokuController {
 
     /**
      * Инициализира EASY Game.
+     *
      * @param actionEvent - събитие.
      */
     @FXML
@@ -97,7 +98,7 @@ public class HomeViewSudokuController {
 
             Player player = new Player(nicknameTxtField.getText());
             Game game = new Game(SudokuLevel.EASY, SudokuLevel.EASY.getMaxEmptyCells(),
-                    b, clientServiceImpl.makeSolution(b, b.length),0, player);
+                    b, clientServiceImpl.makeSolution(b, b.length), 0, player);
 
             Pair<Game, Player> data = new Pair<>(game, player);
             sendSudokuScene(actionEvent, data);
@@ -108,18 +109,18 @@ public class HomeViewSudokuController {
 
     /**
      * Инициализира MEDIUM Game.
+     *
      * @param event - събитие.
-     * @throws RemoteException
      */
     @FXML
-    void onMediumGameBtnClicked(MouseEvent event) throws RemoteException {
+    void onMediumGameBtnClicked(MouseEvent event) {
         try {
             int[][] b = makeBoard(SudokuLevel.MEDIUM);
             ClientService clientServiceImpl = new ClientServiceImpl();
 
             Player player = new Player(nicknameTxtField.getText());
             Game game = new Game(SudokuLevel.MEDIUM, SudokuLevel.MEDIUM.getMaxEmptyCells(),
-                    b, clientServiceImpl.makeSolution(b, b.length),0, player);
+                    b, clientServiceImpl.makeSolution(b, b.length), 0, player);
 
             Pair<Game, Player> data = new Pair<>(game, player);
             sendSudokuScene(event, data);
@@ -130,18 +131,18 @@ public class HomeViewSudokuController {
 
     /**
      * Инициализира HARD Game.
+     *
      * @param event - събитие.
-     * @throws RemoteException
      */
     @FXML
-    void onHardGameBtnClicked(MouseEvent event) throws RemoteException {
+    void onHardGameBtnClicked(MouseEvent event) {
         try {
             int[][] b = makeBoard(SudokuLevel.HARD);
             ClientService clientServiceImpl = new ClientServiceImpl();
 
             Player player = new Player(nicknameTxtField.getText());
             Game game = new Game(SudokuLevel.HARD, SudokuLevel.HARD.getMaxEmptyCells(),
-                    b, clientServiceImpl.makeSolution(b, b.length),0, player);
+                    b, clientServiceImpl.makeSolution(b, b.length), 0, player);
 
             Pair<Game, Player> data = new Pair<>(game, player);
             sendSudokuScene(event, data);

--- a/client.app/src/sudoku/controllers/PlaySudokuController.java
+++ b/client.app/src/sudoku/controllers/PlaySudokuController.java
@@ -1,10 +1,7 @@
 package sudoku.controllers;
 
-import javafx.scene.control.Button;
-import java.net.URL;
-import java.rmi.RemoteException;
-import java.util.ResourceBundle;
 import javafx.fxml.FXML;
+import javafx.scene.control.Button;
 import javafx.scene.control.TextField;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.AnchorPane;
@@ -17,7 +14,11 @@ import server.entities.Player;
 import server.entities.SudokuLevel;
 import sudoku.services.ClientService;
 import sudoku.servicesImpls.ClientServiceImpl;
+
 import javax.swing.*;
+import java.net.URL;
+import java.rmi.RemoteException;
+import java.util.ResourceBundle;
 
 /**
  * Контролер на игралния прозорец.
@@ -47,7 +48,7 @@ public class PlaySudokuController {
 
     @FXML
     private Button helpButton;
-    
+
     @FXML
     private Button newGameButton;
 
@@ -92,10 +93,12 @@ public class PlaySudokuController {
 
         int rowIndex = 0, colIndex = 0;
         for (int i = 0; i < data.getKey().getBoard().length; i++) {
+            GridPane innerGrid = (GridPane) sudokuGrid.getChildren().get(rowIndex);
             for (int j = 0; j < data.getKey().getBoard()[i].length; j++) {
-                ((TextField)((GridPane)pane.getChildren().get(rowIndex)).getChildren()
-                        .get(colIndex++)).setText(String.valueOf(data.getKey().getBoard()[i][j]));
+                ((TextField) innerGrid.getChildren().get(colIndex++))
+                        .setText(Integer.toString(data.getKey().getBoard()[i][j]));
             }
+            colIndex = 0;
             rowIndex++;
         }
 
@@ -106,6 +109,7 @@ public class PlaySudokuController {
 
     /**
      * Отваря инструкциите на играта.
+     *
      * @param event - събитие.
      */
     @FXML
@@ -126,14 +130,15 @@ public class PlaySudokuController {
 
     /**
      * Създава нова игра от същата трудност.
+     *
      * @param event - събитие.
      * @throws RemoteException
      */
     @FXML
     void onNewGameBtnClicked(MouseEvent event) throws RemoteException {
         ClientService cl = new ClientServiceImpl();
-        int[][] board = new int[9][];
-        switch(sudokuLevelLbl.getText()) {
+        int[][] board;
+        switch (sudokuLevelLbl.getText()) {
             case "MEDIUM" -> board = cl.initGame(SudokuLevel.MEDIUM, nicknameLabel.getText());
             case "HARD" -> board = cl.initGame(SudokuLevel.HARD, nicknameLabel.getText());
 
@@ -141,17 +146,22 @@ public class PlaySudokuController {
         }
 
         int rowIndex = 0, colIndex = 0;
-        for (int i = 0; i < board.length; i++) {
-            for (int j = 0; j < board[i].length; j++) {
-                ((TextField)((GridPane)pane.getChildren().get(rowIndex)).getChildren()
-                        .get(colIndex++)).setText(String.valueOf(board[i][j]));
+        for (int[] boardRow : board) {
+            GridPane innerGrid = (GridPane) sudokuGrid.getChildren().get(rowIndex);
+            for (int boardCol : boardRow) {
+                if (boardCol != 0) {
+                    ((TextField) innerGrid.getChildren().get(colIndex)).setText(Integer.toString(boardCol));
+                }
+                colIndex++;
             }
+            colIndex = 0;
             rowIndex++;
         }
     }
 
     /**
      * Премества един ход напред.
+     *
      * @param event - събитие.
      */
     @FXML
@@ -161,6 +171,7 @@ public class PlaySudokuController {
 
     /**
      * Връща един ход назад.
+     *
      * @param event - събитие.
      */
     @FXML

--- a/client.app/src/sudoku/services/ClientService.java
+++ b/client.app/src/sudoku/services/ClientService.java
@@ -1,4 +1,5 @@
 package sudoku.services;
+
 import server.entities.Game;
 import server.entities.Player;
 import server.entities.SudokuLevel;
@@ -12,7 +13,8 @@ import java.rmi.RemoteException;
 public interface ClientService extends Remote {
     /**
      * Инициализира дъската за игра.
-     * @param level - ниво на трудност.
+     *
+     * @param level    - ниво на трудност.
      * @param nickname - никнейм.
      * @return инициализирана дъска за игра.
      * @throws RemoteException
@@ -21,8 +23,9 @@ public interface ClientService extends Remote {
 
     /**
      * Решава частично судокото чрез backtracking технология.
+     *
      * @param board - дъска за игра.
-     * @param N - брой редове/колони.
+     * @param N     - брой редове/колони.
      * @return Връща решено судоку.
      * @throws RemoteException
      */
@@ -30,6 +33,7 @@ public interface ClientService extends Remote {
 
     /**
      * Ъпдейтва дъската за игра.
+     *
      * @param updatedGridBoard - ъпдейтната дъска за игра.
      * @throws RemoteException
      */
@@ -37,12 +41,13 @@ public interface ClientService extends Remote {
 
     /**
      * Показва съобщение на потреббителя за различни неща (победа/загуба).
-     * @param title - заглавие.
-     * @param message - съобщение.
-     * @param player - играч.
-     * @param game - игра.
-     * @param toatalMinutes - минути, за които е решено судокуто.
+     *
+     * @param title        - заглавие.
+     * @param message      - съобщение.
+     * @param player       - играч.
+     * @param game         - игра.
+     * @param totalMinutes - минути, за които е решено судокуто.
      * @throws RemoteException
      */
-    void showMessage(String title, String message, Player player, Game game, int toatalMinutes)throws RemoteException;
+    void showMessage(String title, String message, Player player, Game game, int totalMinutes) throws RemoteException;
 }

--- a/client.app/src/sudoku/servicesImpls/ClientServiceImpl.java
+++ b/client.app/src/sudoku/servicesImpls/ClientServiceImpl.java
@@ -1,14 +1,15 @@
 package sudoku.servicesImpls;
+
 import server.entities.Game;
 import server.entities.Player;
 import server.entities.SudokuLevel;
 import server.services.SudokuService;
 import server.servicesImpls.SudokuServiceImpl;
 import sudoku.services.ClientService;
+
 import javax.swing.*;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.rmi.AccessException;
 import java.rmi.RemoteException;
 import java.rmi.registry.LocateRegistry;
 import java.rmi.registry.Registry;
@@ -25,9 +26,10 @@ public class ClientServiceImpl implements ClientService {
 
     /**
      * Проверява дали дадена позиция е безопасна.
-     * @param board - дъска.
-     * @param rowI - индекс на ред.
-     * @param colI - индекс на колона.
+     *
+     * @param board     - дъска.
+     * @param rowI      - индекс на ред.
+     * @param colI      - индекс на колона.
      * @param cellValue - стойност.
      * @return true - при безопасна,false - при небезопасна
      */
@@ -39,13 +41,13 @@ public class ClientServiceImpl implements ClientService {
                 return false;
             }
         }
-        for (int rowIndex = 0; rowIndex < board.length; ++rowIndex) {
-            if (board[rowIndex][colI] == cellValue) {
+        for (int[] boardRow : board) {
+            if (boardRow[colI] == cellValue) {
                 return false;
             }
         }
 
-        int sqrt = (int)Math.sqrt(board.length);
+        int sqrt = (int) Math.sqrt(board.length);
         int boxRowStartIndex = rowI - rowI % sqrt;
         int boxColStartIndex = colI - colI % sqrt;
 
@@ -64,7 +66,8 @@ public class ClientServiceImpl implements ClientService {
 
     /**
      * Решава судоку пъзела.
-     * @param board - дъска.
+     *
+     * @param board            - дъска.
      * @param numberOfRowsCols - брой редове/колони
      * @return true - при решено судоку, false - при нерешено судоку
      */
@@ -95,8 +98,7 @@ public class ClientServiceImpl implements ClientService {
                 board[rowIndex][colIndex] = currentCellValue;
                 if (solveSudoku(board, numberOfRowsCols)) {
                     return true;
-                }
-                else {
+                } else {
                     board[rowIndex][colIndex] = 0;
                 }
             }
@@ -110,14 +112,12 @@ public class ClientServiceImpl implements ClientService {
         Player player = new Player(nickname);
         Game game = new Game();
         try {
-            Registry r = LocateRegistry.getRegistry ("localhost",1099);
+            Registry r = LocateRegistry.getRegistry("localhost", 1099);
             SudokuService server = null;
             try {
-                server = new SudokuServiceImpl(player,game);
+                server = new SudokuServiceImpl(player, game);
                 server.fillValues();
 
-            } catch (AccessException ex) {
-                logger.log(Level.SEVERE, ex.getMessage());
             } catch (IOException ex) {
                 logger.log(Level.SEVERE, ex.getMessage());
             }
@@ -131,7 +131,7 @@ public class ClientServiceImpl implements ClientService {
     @Override
     public int[][] makeSolution(int[][] board, int N) throws RemoteException {
         int[][] solved = new int[N][N];
-        if(solveSudoku(board, N)) {
+        if (solveSudoku(board, N)) {
             for (int r = 0; r < N; r++) {
                 for (int d = 0; d < N; d++) {
                     solved[r][d] = board[r][d];
@@ -152,21 +152,22 @@ public class ClientServiceImpl implements ClientService {
     }
 
     @Override
-    public void showMessage(String title, String message, Player player, Game game, int toatalMinutes) throws RemoteException {
+    public void showMessage(String title, String message, Player player, Game game, int totalMinutes) throws RemoteException {
         JOptionPane.showMessageDialog(null, message, title, JOptionPane.INFORMATION_MESSAGE);
-        logClientGameOutcome(player.getNickname(), game.getLevel(), game.getCurrentScore(), game.isWon(), toatalMinutes);
+        logClientGameOutcome(player.getNickname(), game.getLevel(), game.getCurrentScore(), game.isWon(), totalMinutes);
     }
 
     /**
      * Логва резултата (победа/загуба) на играта.
-     * @param nickname - никнейм.
-     * @param level - ниво на трудност.
-     * @param totalScore - краен резултат.
-     * @param isWon - дали е победа или не.
+     *
+     * @param nickname     - никнейм.
+     * @param level        - ниво на трудност.
+     * @param totalScore   - краен резултат.
+     * @param isWon        - дали е победа или не.
      * @param totalMinutes - брой на минути за решаване.
      */
     private void logClientGameOutcome(String nickname, SudokuLevel level, int totalScore, boolean isWon,
-                                     int totalMinutes) {
+                                      int totalMinutes) {
         String fileName = nickname + "_sudoku_outcome.txt";
         LocalDate currentDate = LocalDate.now();
 

--- a/remote.obj/src/module-info.java
+++ b/remote.obj/src/module-info.java
@@ -1,7 +1,7 @@
 module remote.obj {
     requires java.rmi;
     requires java.logging;
-    exports server;
+
     exports server.entities;
     exports server.services;
     exports server.servicesImpls;


### PR DESCRIPTION
>
> + Needs to use opens [package with controllers] to javafx.fxml
> + Make board -> made into inline return variable
> + Fixed issue with loading the sudoku scene (Needed to fix the path to /sudoku/fxmls/PlaySudoku.fxml
>   Note: You don't need to close the stage as it closes the app, just change the scenes) {For HomeViewSudokuController}
> + {For PlaySudokuController}: Anchor panes must be changed to the main gridpane, anchor pane has other children than only the main grid
> Changed to grid pane and modified some for loops
> + For loops never make the cols to zero --> results in exception
> + {For remote.obj.module-info}: You don't need to export packages with classes and interfaces that wont be used by other modules
> P.S. you can add 'to' after the export to send it to  only specific modules